### PR TITLE
fix(react-table-responsive): now client table is able to take custom …

### DIFF
--- a/packages/react-table-responsive/src/components/ClientTable/ClientTable.js
+++ b/packages/react-table-responsive/src/components/ClientTable/ClientTable.js
@@ -69,6 +69,7 @@ export default function ClientTable({
   // if it is true filters and sortBy will be stored in memory and when you go back to the table its state will be initialized with it
   // it is stored in a const variable thus state dissapears on page reload
   enableTableStatePersistance = false,
+  ...props
 }) {
   if (!tableId) {
     throw new Error('non-empty and globally unique tableId is required');
@@ -95,6 +96,7 @@ export default function ClientTable({
       },
       disableMultiSort: true,
       disableSortRemove: true,
+      ...props,
     },
     useResizeColumns,
     useFlexLayout,

--- a/packages/react-table-responsive/src/components/ServerTable/ServerTable.js
+++ b/packages/react-table-responsive/src/components/ServerTable/ServerTable.js
@@ -59,6 +59,7 @@ export default function ServerTable({
   // if it is true filters and sortBy will be stored in memory and when you go back to the table its state will be initialized with it
   // it is stored in a const variable thus state dissapears on page reload
   enableTableStatePersistance = false,
+  ...props
 }) {
   if (!tableId) {
     throw new Error('non-empty and globally unique tableId is required');
@@ -114,6 +115,7 @@ export default function ServerTable({
       manualFilters: true,
       manualSortBy: true,
       pageCount,
+      ...props,
     },
     useResizeColumns,
     useFlexLayout,


### PR DESCRIPTION
…props, so anything we put into will automatically be available on the instance. for example, this allows to share one function (like data update) between all cell renderers